### PR TITLE
tools: cloud: fix return code handling for create

### DIFF
--- a/src/infuse_iot/tools/cloud.py
+++ b/src/infuse_iot/tools/cloud.py
@@ -76,7 +76,7 @@ class Organisations(CloudSubCommand):
             body=NewOrganisation(self.args.name),
         )
 
-        if rsp.status_code == HTTPStatus.OK:
+        if rsp.status_code == HTTPStatus.CREATED:
             print(f"Created organisation {rsp.parsed.name} with ID {rsp.parsed.id}")
         else:
             c = loads(rsp.content.decode("utf-8"))
@@ -144,7 +144,7 @@ class Boards(CloudSubCommand):
                 organisation_id=self.args.org,
             ),
         )
-        if rsp.status_code == HTTPStatus.OK:
+        if rsp.status_code == HTTPStatus.CREATED:
             print(f"Created board {rsp.parsed.name} with ID {rsp.parsed.id}")
         else:
             c = loads(rsp.content.decode("utf-8"))


### PR DESCRIPTION
Fix using an incorrect return code to check if a create operation succeeds.
This caused the scripts to crash when attempting to create an organisation by attempting to read the response message on success. Changed return code 200 to 201 to match the [api docs](https://api.dev.infuse-iot.com/docs#tag/default/POST/organisation).