### PR TITLE
tools: normalise LocalClient timeout

### DIFF
--- a/src/infuse_iot/tools/bt_log.py
+++ b/src/infuse_iot/tools/bt_log.py
@@ -25,7 +25,7 @@ class SubCommand(InfuseCommand):
     DESCRIPTION = "Connect to remote Bluetooth device serial logs"
 
     def __init__(self, args):
-        self._client = LocalClient(default_multicast_address(), 60.0)
+        self._client = LocalClient(default_multicast_address(), 1.0)
         self._decoder = TDF()
         self._id = args.id
         self._data = args.data

--- a/src/infuse_iot/tools/data_logger_sync.py
+++ b/src/infuse_iot/tools/data_logger_sync.py
@@ -64,7 +64,7 @@ class SubCommand(InfuseCommand):
     DESCRIPTION = "Synchronise data logger state from remote devices"
 
     def __init__(self, args):
-        self._client = LocalClient(default_multicast_address(), 60.0)
+        self._client = LocalClient(default_multicast_address(), 1.0)
         self._min_rssi: int | None = args.rssi
         self._app = args.app
         self._out = args.out

--- a/src/infuse_iot/tools/ota_upgrade.py
+++ b/src/infuse_iot/tools/ota_upgrade.py
@@ -35,7 +35,7 @@ class SubCommand(InfuseCommand):
     DESCRIPTION = "Automatically OTA upgrade observed devices"
 
     def __init__(self, args):
-        self._client = LocalClient(default_multicast_address(), 60.0)
+        self._client = LocalClient(default_multicast_address(), 1.0)
         self._min_rssi: int | None = args.rssi
         self._single_id: int | None = args.id
         self._release: ValidRelease = args.release

--- a/src/infuse_iot/tools/rpc.py
+++ b/src/infuse_iot/tools/rpc.py
@@ -53,7 +53,7 @@ class SubCommand(InfuseCommand):
 
     def __init__(self, args: argparse.Namespace):
         self._args = args
-        self._client = LocalClient(default_multicast_address(), 10.0)
+        self._client = LocalClient(default_multicast_address(), 1.0)
         self._command: InfuseRpcCommand = args.rpc_class(args)
         self._request_id = random.randint(0, 2**32 - 1)
         self._max_payload = 0


### PR DESCRIPTION
Normalise the LocalClient timeouts to 1 second, since on Windows Keyboard interrupts can only be handled after the blocking receive returns or times out.