### PR TITLE
rpc_client: fix handling of early RPC_RSP

### DIFF
--- a/src/infuse_iot/rpc_client.py
+++ b/src/infuse_iot/rpc_client.py
@@ -136,7 +136,9 @@ class RpcClient:
 
             # Wait for ACKs at the period
             if ack_cnt == ack_period:
-                self._wait_data_ack()
+                recv = self._wait_data_ack()
+                if recv.ptype == InfuseType.RPC_RSP:
+                    return self._finalise_command(recv, rsp_decoder)
                 ack_cnt = 0
 
             offset += size


### PR DESCRIPTION
Properly handle `RPC_RSP` packets that arrive when expecting an `RPC_DATA_ACK` packet.