### PR TITLE
tools: native_bt: handle unknown networks

### DIFF
--- a/src/infuse_iot/database.py
+++ b/src/infuse_iot/database.py
@@ -112,7 +112,7 @@ class DeviceDatabase:
             try:
                 info = load_network(network_id)
             except FileNotFoundError:
-                raise UnknownNetworkError from None
+                raise UnknownNetworkError(network_id) from None
             self._network_keys[network_id] = info["key"]
         base = self._network_keys[network_id]
         time_idx = gps_time // (60 * 60 * 24)


### PR DESCRIPTION
Ignore unknown networks rather than letting the exceptions flow up the stack.