### PR TITLE
rpc_client: support chunked data sending

### DIFF
--- a/src/infuse_iot/commands.py
+++ b/src/infuse_iot/commands.py
@@ -46,6 +46,7 @@ class InfuseCommand(metaclass=ABCMeta):
 
 class InfuseRpcCommand:
     RPC_DATA_SEND = False
+    RPC_DATA_SEND_CHUNKED = False
     RPC_DATA_RECEIVE = False
 
     @classmethod
@@ -69,6 +70,10 @@ class InfuseRpcCommand:
 
     def data_payload(self) -> bytes:
         """Payload to send with RPC_DATA"""
+        raise NotImplementedError
+
+    def data_payload_chunked(self) -> list[bytes]:
+        """Payloads to send with RPC_DATA"""
         raise NotImplementedError
 
     def data_payload_recv_len(self) -> int:

--- a/src/infuse_iot/generated/rpc_definitions.py
+++ b/src/infuse_iot/generated/rpc_definitions.py
@@ -986,7 +986,9 @@ class data_receiver:
     COMMAND_ID = 32766
 
     class request(VLACompatLittleEndianStruct):
-        _fields_ = []
+        _fields_ = [
+            ("unaligned_input", ctypes.c_uint8),
+        ]
         _pack_ = 1
 
     class response(VLACompatLittleEndianStruct):

--- a/src/infuse_iot/rpc_client.py
+++ b/src/infuse_iot/rpc_client.py
@@ -162,6 +162,17 @@ class RpcClient:
         # Run with pre-computed chunks
         return self._run_data_send_core(cmd_id, auth, params, chunks, len(data), False, progress_cb, rsp_decoder)
 
+    def run_data_send_cmd_chunked(
+        self,
+        cmd_id: int,
+        auth: Auth,
+        params: bytes,
+        data: list[bytes],
+        progress_cb: Callable[[int], None] | None,
+        rsp_decoder: Callable[[bytes], ctypes.LittleEndianStructure],
+    ) -> tuple[rpc.ResponseHeader, ctypes.LittleEndianStructure | None]:
+        return self._run_data_send_core(cmd_id, auth, params, data, len(data), True, progress_cb, rsp_decoder)
+
     def run_data_recv_cmd(
         self,
         cmd_id: int,

--- a/src/infuse_iot/rpc_wrappers/lte_at_cmd.py
+++ b/src/infuse_iot/rpc_wrappers/lte_at_cmd.py
@@ -29,9 +29,12 @@ class lte_at_cmd(InfuseRpcCommand, defs.lte_at_cmd):
         return {"cmd": self.args.cmd}
 
     def handle_response(self, return_code, response):
+        if response:
+            # Print returned strings even on failure
+            response_bytes = bytes(response.rsp)
+            if len(response_bytes):
+                decoded = bytes(response.rsp).decode("utf-8").strip()
+                print(decoded)
+        # Notification that command failed
         if return_code != 0:
             print(f"Failed to run command ({errno.strerror(-return_code)})")
-            return
-        decoded = bytes(response.rsp).decode("utf-8").strip()
-
-        print(decoded)

--- a/src/infuse_iot/tools/rpc.py
+++ b/src/infuse_iot/tools/rpc.py
@@ -97,6 +97,15 @@ class SubCommand(InfuseCommand):
                         self._command.data_progress_cb,
                         decode_fn,
                     )
+                elif self._command.RPC_DATA_SEND_CHUNKED:
+                    hdr, rsp = rpc_client.run_data_send_cmd_chunked(
+                        self._command.COMMAND_ID,  # type: ignore
+                        self._command.auth_level(),
+                        params,
+                        self._command.data_payload_chunked(),
+                        self._command.data_progress_cb,
+                        decode_fn,
+                    )
                 elif self._command.RPC_DATA_RECEIVE:
                     hdr, rsp = rpc_client.run_data_recv_cmd(
                         self._command.COMMAND_ID,  # type: ignore


### PR DESCRIPTION
Support sending pre-chunked data for RPCs. In this mode, the offset in the data header refers to the packet index, not the raw binary offset.