### PR TITLE
Small type annotation updates

### DIFF
--- a/src/infuse_iot/commands.py
+++ b/src/infuse_iot/commands.py
@@ -60,7 +60,7 @@ class InfuseRpcCommand:
         """Authentication level to run command with"""
         return Auth.DEVICE
 
-    def request_struct(self) -> ctypes.LittleEndianStructure:
+    def request_struct(self) -> ctypes.LittleEndianStructure | bytes:
         """RPC_CMD request structure"""
         raise NotImplementedError
 

--- a/src/infuse_iot/util/argparse.py
+++ b/src/infuse_iot/util/argparse.py
@@ -58,7 +58,7 @@ class BtLeAddress:
         pattern = r"((([0-9a-fA-F]{2}):){5})([0-9a-fA-F]{2})"
 
         if re.match(pattern, string):
-            mac_cleaned = string.replace(":", "").replace("-", "")
+            mac_cleaned = string.replace(":", "")
             addr = int(mac_cleaned, 16)
         else:
             try:

--- a/src/infuse_iot/util/argparse.py
+++ b/src/infuse_iot/util/argparse.py
@@ -12,12 +12,15 @@ from infuse_iot.util.ctypes import bytes_to_uint8
 
 
 class ValidFile:
-    """Filesystem path that exists"""
+    """Filesystem file that exists"""
 
     def __new__(cls, string) -> pathlib.Path:  # type: ignore
         p = pathlib.Path(string)
         if p.exists():
-            return p
+            if p.is_dir():
+                raise argparse.ArgumentTypeError(f"{string} is a directory")
+            else:
+                return p
         else:
             raise argparse.ArgumentTypeError(f"{string} does not exist")
 

--- a/tests/util/test_argparse.py
+++ b/tests/util/test_argparse.py
@@ -1,0 +1,46 @@
+import argparse
+import os
+import pathlib
+
+import pytest
+
+from infuse_iot.util.argparse import BtLeAddress, ValidDir, ValidFile
+
+assert "TOXTEMPDIR" in os.environ, "you must run these tests using tox"
+
+
+def test_valid_file():
+    test_file = __file__
+    test_dir = str(pathlib.Path(test_file).parent)
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        ValidFile("random_file_doesnt_exist.txt")
+    with pytest.raises(argparse.ArgumentTypeError):
+        ValidFile(test_dir)
+    parsed = ValidFile(test_file)
+    assert isinstance(parsed, pathlib.Path)
+
+
+def test_valid_directory():
+    test_file = __file__
+    test_dir = str(pathlib.Path(test_file).parent)
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        ValidDir("random_folder_doesnt_exist")
+    with pytest.raises(argparse.ArgumentTypeError):
+        ValidDir(test_file)
+    parsed = ValidDir(test_dir)
+    assert isinstance(parsed, pathlib.Path)
+
+
+def test_bt_le_address():
+    with pytest.raises(argparse.ArgumentTypeError):
+        BtLeAddress("NotAnAddress")
+    with pytest.raises(argparse.ArgumentTypeError):
+        BtLeAddress("XX:XX:XX:XX:XX:XX")
+    with pytest.raises(argparse.ArgumentTypeError):
+        BtLeAddress("12:34:56:aa:FF")
+    addr = BtLeAddress("12:34:56:aa:FF:4A")
+    assert isinstance(addr, int)
+    addr = BtLeAddress("123456aaFF4A")
+    assert isinstance(addr, int)


### PR DESCRIPTION
Command implementations can validly return a `bytes` object from `request_struct`.

Update `ValidFile` to reject directories.