### PR TITLE
rpc_wrappers: data_logger_erase: longer timeout

### DIFF
--- a/src/infuse_iot/commands.py
+++ b/src/infuse_iot/commands.py
@@ -60,6 +60,10 @@ class InfuseRpcCommand:
         """Authentication level to run command with"""
         return Auth.DEVICE
 
+    def command_timeout_ms(self) -> int:
+        """Duration to wait for the RPC response in milliseconds"""
+        return 10000
+
     def request_struct(self) -> ctypes.LittleEndianStructure | bytes:
         """RPC_CMD request structure"""
         raise NotImplementedError

--- a/src/infuse_iot/rpc_wrappers/data_logger_erase.py
+++ b/src/infuse_iot/rpc_wrappers/data_logger_erase.py
@@ -16,9 +16,12 @@ class data_logger_erase(InfuseRpcCommand, defs.data_logger_erase):
             action="store_true",
             help="Erase entire address space, not just written blocks",
         )
+        # Erasing a complete flash chip can take a long time
+        parser.add_argument("--timeout", type=int, default=60000, help="Duration to wait for erase to complete")
 
     def __init__(self, args):
         self.infuse_id = args.id
+        self.timeout = args.timeout
         if args.onboard:
             self.logger = defs.rpc_enum_data_logger.FLASH_ONBOARD
         elif args.removable:
@@ -26,6 +29,9 @@ class data_logger_erase(InfuseRpcCommand, defs.data_logger_erase):
         else:
             raise NotImplementedError
         self.erase_all = 1 if args.erase_all else 0
+
+    def command_timeout_ms(self) -> int:
+        return self.timeout
 
     def request_struct(self):
         return self.request(self.logger, self.erase_all)

--- a/src/infuse_iot/rpc_wrappers/data_logger_erase.py
+++ b/src/infuse_iot/rpc_wrappers/data_logger_erase.py
@@ -11,10 +11,16 @@ class data_logger_erase(InfuseRpcCommand, defs.data_logger_erase):
         logger = parser.add_mutually_exclusive_group(required=True)
         logger.add_argument("--onboard", action="store_true", help="Onboard flash logger")
         logger.add_argument("--removable", action="store_true", help="Removable flash logger (SD)")
-        parser.add_argument(
+        erase_mode = parser.add_mutually_exclusive_group()
+        erase_mode.add_argument(
             "--erase-all",
             action="store_true",
             help="Erase entire address space, not just written blocks",
+        )
+        erase_mode.add_argument(
+            "--erase-force",
+            action="store_true",
+            help="Erase entire address space, even if logger init failed",
         )
         # Erasing a complete flash chip can take a long time
         parser.add_argument("--timeout", type=int, default=60000, help="Duration to wait for erase to complete")
@@ -28,7 +34,7 @@ class data_logger_erase(InfuseRpcCommand, defs.data_logger_erase):
             self.logger = defs.rpc_enum_data_logger.FLASH_REMOVABLE
         else:
             raise NotImplementedError
-        self.erase_all = 1 if args.erase_all else 0
+        self.erase_all = 1 if args.erase_all else (0xAA if args.erase_force else 0)
 
     def command_timeout_ms(self) -> int:
         return self.timeout

--- a/src/infuse_iot/tools/rpc.py
+++ b/src/infuse_iot/tools/rpc.py
@@ -85,6 +85,7 @@ class SubCommand(InfuseCommand):
             with self._client.connection(self._id, types, self._args.conn_timeout) as mtu:
                 self._max_payload = mtu
                 rpc_client = RpcClient(self._client, mtu, self._id, self.rx_handler)
+                rpc_client.set_timeout(self._command.command_timeout_ms())
                 params = bytes(self._command.request_struct())
 
                 if hasattr(self._command.response, "vla_from_buffer_copy"):  # type: ignore


### PR DESCRIPTION
Make the `data_logger_erase` command have a longer, configurable, RPC timeout.