### PR TITLE
rpc_wrappers: lte_at_cmd: echo provided command

### DIFF
--- a/src/infuse_iot/rpc_wrappers/lte_at_cmd.py
+++ b/src/infuse_iot/rpc_wrappers/lte_at_cmd.py
@@ -34,6 +34,7 @@ class lte_at_cmd(InfuseRpcCommand, defs.lte_at_cmd):
             response_bytes = bytes(response.rsp)
             if len(response_bytes):
                 decoded = bytes(response.rsp).decode("utf-8").strip()
+                print(f"> {self.args.cmd}")
                 print(decoded)
         # Notification that command failed
         if return_code != 0:


### PR DESCRIPTION
Echo the provided command when the response is received. AT commands can include the `$` character for vendor specific extensions, which can cause shell substitution problems (wrap like this 'AT$CMD' to disable shell expansion). Printing the command sent makes these errors more obvious.