### PR TITLE
socket_comms: fix multicast sockets on Windows without IP

### DIFF
--- a/src/infuse_iot/socket_comms.py
+++ b/src/infuse_iot/socket_comms.py
@@ -273,8 +273,7 @@ class LocalServer:
         # Multicast output socket
         self._output_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         self._output_sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
-        if sys.platform != "win32":
-            self._output_sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton("127.0.0.1"))
+        self._output_sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_IF, socket.inet_aton("127.0.0.1"))
         self._output_addr = multicast_address
         # Single input socket
         unicast_address = ("localhost", multicast_address[1] + 1)
@@ -303,11 +302,10 @@ class LocalClient:
         self._input_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
         self._input_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         if sys.platform == "win32":
-            self._input_sock.bind(("", multicast_address[1]))
-            mreq = struct.pack("4sl", socket.inet_aton(multicast_address[0]), socket.INADDR_ANY)
+            self._input_sock.bind(("127.0.0.1", multicast_address[1]))
         else:
             self._input_sock.bind(multicast_address)
-            mreq = struct.pack("4s4s", socket.inet_aton(multicast_address[0]), socket.inet_aton("127.0.0.1"))
+        mreq = struct.pack("4s4s", socket.inet_aton(multicast_address[0]), socket.inet_aton("127.0.0.1"))
         self._input_sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
         self._input_sock.settimeout(rx_timeout)
         # Unicast output socket


### PR DESCRIPTION
Fix multicast sockets on Windows when there is no multicast capable external interface. The writing socket is now unconditionally bound to the localhost interface, and the receiving socket updated to be properly bound to the multicast group on Windows.