### PR TITLE
util: soc: stm: reverse MCU ID bytes

### DIFF
--- a/src/infuse_iot/util/soc/stm.py
+++ b/src/infuse_iot/util/soc/stm.py
@@ -126,7 +126,7 @@ class Interface(ProvisioningInterface):
 
         # Byte order matches that returned by `hwinfo_stm32`
         id_bytes = word2.to_bytes(4, "big") + word1.to_bytes(4, "big") + word0.to_bytes(4, "big")
-        return int.from_bytes(id_bytes, "big")
+        return int.from_bytes(id_bytes, "little")
 
     @staticmethod
     def unique_device_id_fields(uid: int) -> dict:


### PR DESCRIPTION
Reverse MCU ID bytes for STM platforms so that the relative byte ordering provided to the cloud matches that done for Nordic. This allows the cloud to apply the same parsing of a MCU ID in a `security_state` response for all SoCs.